### PR TITLE
do a build dryrun on pushes, setup QEMU

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "arm-linux-gnueabihf-ld"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -6,28 +6,45 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions/checkout@v2
+    - uses: Swatinem/rust-cache@v1
+    - uses: actions/checkout@v2
 
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+    - name: cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
 
-      - name: cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+    - name: cargo fmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
 
-      - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+    - name: cargo clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: -- -D warnings
+  build:
+    name: build
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Confirm Build
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,9 @@ jobs:
         username: goshlanguage
         password: ${{ secrets.GHCR_TOKEN }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 


### PR DESCRIPTION
The arm builds still fail when cutting a release. 

QEMU wasn't being setup in the build pipeline so I'm hoping that's the delta, given that it builds locally with `docker buildx build` on the currently configured platforms. 

Looks like that was the trouble, given this build has passed instead of the error that was occurring before on the arm64 build:

```
#14 81.86 error: could not compile `proc-macro2` due to previous error
#14 81.86 warning: build failed, waiting for other jobs to finish...
#14 84.23 error: failed to compile `mate v0.1.0 (/usr/src/mate)`, intermediate artifacts can be found at `/usr/src/mate/target`
#14 84.23 
#14 84.23 Caused by:
#14 84.23   build failed
```