### PR TITLE
Address SSL issue with kraken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY . .
 RUN cargo install --path .
 
 FROM debian:bullseye-slim
+RUN apt update && \
+  apt install -y ca-certificates
 COPY --from=builder /usr/local/cargo/bin/mate /usr/local/bin/mate
 COPY --from=builder /usr/local/cargo/bin/mate-collector /usr/local/bin/mate-collector
 COPY --from=builder /usr/local/cargo/bin/mate-api /usr/local/bin/mate-api


### PR DESCRIPTION
When the collector is enabled and attempts to connect to `kraken`, it's throwing a TLS error about not being to validate the SSL:

```
[2022-01-06T03:30:15Z ERROR mate_collector::types] Reqwest error: error sending request for url (https://api.kraken.com/0/public/Ticker): error trying to connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1913: (unable to get local issuer certificate)
```

By default, the build target image, `debian:bullseye-slim`, doesn't ship with `ca-certificates` by default. This PR adds it to the build target.